### PR TITLE
Added callback to populate symbols tree view when new file is opened.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ In Atom 1.17, a new UI component called "docks" are introduced. Symbols Navigato
 * **`Alternative Ctags Binary`** You can specify a path to a binary to use for ctags instead of the original one in symbols-navigator.
 *This implementation comes from [symbols-tree-nav](https://atom.io/packages/symbols-tree-nav).*
 * **`Click Type`** (default=Double Click) You can specify which clicking event to trigger moving cursor to the symbol.
+* **`Scroll Type`** (default=Quickest) Specifies how the editor will scroll to show the symbol at a specific location in the editor. i.e.: Top means the symbol will be shown on the top of the editor window. Possible options: Quickest, Top, Center, Bottom
 * **`Show Current Symbol On Status Bar`** (default=false) If checked then symbols-navigator will show current symbol on status bar.
 
 ## Supported commands

--- a/lib/symbols-navigator-view.js
+++ b/lib/symbols-navigator-view.js
@@ -41,6 +41,11 @@ export default class SymbolsNavigatorView {
       this.populate();
     }));
 
+    this.subscriptions.add(atom.workspace.onDidOpen(() => {
+      this.removeEventForEditor();
+      this.populate();
+    }));
+
     this.removeEventForEditor();
     this.populate();
     this.keyboardEvents();

--- a/lib/symbols-navigator.js
+++ b/lib/symbols-navigator.js
@@ -82,12 +82,20 @@ export default {
       description: 'Here you can change which clicking event triggers moving cursor to the symbol.',
       order: 11,
     },
+    scrollType: {
+      title: 'Scroll Type',
+      type: 'string',
+      default: 'Quickest',
+      enum: ['Quickest', 'Top', 'Center', 'Bottom'],
+      description: 'Sets how to scroll to a symbol. Quickest means, the editor will scroll until the symbol appears anywhere in the editor. Top/Center/Bottom means, the editor will scroll until the symbol is at the top/center/bottom of the editor.',
+      order: 12,
+    },
     showOnStatusBar: {
       title: 'Show Current Symbol On Status Bar',
       type: 'boolean',
       description: 'If this option is enabled, then symbols-navigator will show current symbol on status bar.',
       default: false,
-      order: 12,
+      order: 13,
     },
   },
 

--- a/lib/tag-generator.js
+++ b/lib/tag-generator.js
@@ -15,6 +15,20 @@ export default class TagGenerator {
     if (line.length > 0 && line[0] === '{') {
       let sections = {};
       try {
+        // escape the signatures to allow correct parsing
+        let searchString = "\"signature\":\"(";
+        let startpos = line.indexOf(searchString);
+        if(startpos!=-1){
+          startpos = startpos + searchString.length;
+          let endpos = line.lastIndexOf("\"");
+          line = line.substring(0, startpos) +
+            line.substring(startpos, endpos)
+            .replace(/\\/g, "\\\\")
+            .replace(/\$/g, "\\$")
+            .replace(/'/g, "\\'")
+            .replace(/"/g, "\\\"") +
+            line.substring(endpos);
+      }
         sections = JSON.parse(line);
       } catch (exception) {
         return null;

--- a/lib/tree-view.js
+++ b/lib/tree-view.js
@@ -245,17 +245,7 @@ export default class TreeView {
     currentNode.classList.add('selected');
 
     if (atom.config.get('symbols-navigator.clickType') === 'Single Click') {
-      const editor = atom.workspace.getActiveTextEditor();
-      if (moveCursor && currentNode.dataset.row && currentNode.dataset.row >= 0 && editor != null) {
-        const position = new Point(parseInt(currentNode.dataset.row, 10));
-        editor.scrollToBufferPosition(position, {
-          center: true,
-        });
-        editor.setCursorBufferPosition(position);
-        editor.moveToFirstCharacterOfLine();
-        editor.element.dispatchEvent(new CustomEvent('focus'));
-        this.statusBarManager.updateTitle(currentNode.dataset.title);
-      }
+      this.moveToSelectedSymbol();
     }
   }
 
@@ -290,14 +280,7 @@ export default class TreeView {
     if (atom.config.get('symbols-navigator.clickType') === 'Double Click') {
       const editor = atom.workspace.getActiveTextEditor();
       if (moveCursor && currentNode.dataset.row && currentNode.dataset.row >= 0 && editor != null) {
-        const position = new Point(parseInt(currentNode.dataset.row, 10));
-        editor.scrollToBufferPosition(position, {
-          center: true,
-        });
-        editor.setCursorBufferPosition(position);
-        editor.moveToFirstCharacterOfLine();
-        editor.element.dispatchEvent(new CustomEvent('focus'));
-        this.statusBarManager.updateTitle(currentNode.dataset.title);
+        this.moveToSelectedSymbol();
       }
     }
   }
@@ -399,12 +382,38 @@ export default class TreeView {
     const selectedNode = this.element.querySelector('.selected');
     if (selectedNode.dataset.row && selectedNode.dataset.row >= 0 && editor != null) {
       const position = new Point(parseInt(selectedNode.dataset.row, 10));
-      editor.scrollToBufferPosition(position, {
-        center: true,
-      });
-      editor.setCursorBufferPosition(position);
-      editor.moveToFirstCharacterOfLine();
-      editor.element.dispatchEvent(new CustomEvent('focus'));
+      var scrollPosition = position;
+
+      // if not quickscrolling, calculate how the editor window has to be shifted to align
+      // the selected item on top or bottom
+      if(atom.config.get('symbols-navigator.scrollType') === 'Top'){
+        if(editor.getCursorBufferPosition().isLessThan(position)){
+          tempPoint = new Point(Math.round(position.row+editor.getRowsPerPage()*0.9), 0)
+          scrollPosition = editor.clipBufferPosition(tempPoint)
+        }
+      } else if(atom.config.get('symbols-navigator.scrollType') === 'Bottom'){
+        if(editor.getCursorBufferPosition().isGreaterThan(position)){
+          tempPoint = new Point(Math.round(position.row-editor.getRowsPerPage()*0.9), 0)
+          scrollPosition = editor.clipBufferPosition(tempPoint)
+        }
+      } else if(atom.config.get('symbols-navigator.scrollType') === 'Center'){
+        if(editor.getCursorBufferPosition().isLessThan(position)){
+          tempPoint = new Point(Math.round(position.row+editor.getRowsPerPage()*0.45), 0)
+          scrollPosition = editor.clipBufferPosition(tempPoint)
+        } else {
+          tempPoint = new Point(Math.round(position.row-editor.getRowsPerPage()*0.45), 0)
+          scrollPosition = editor.clipBufferPosition(tempPoint)
+        }
+      }
+
+
+      editor.scrollToBufferPosition(scrollPosition);
+      setTimeout(function() {   // setting the cursor has to be delayed for scrolling to work correctly
+        editor.setCursorBufferPosition(position);
+        editor.moveToFirstCharacterOfLine();
+        editor.element.dispatchEvent(new CustomEvent('focus'));
+      }, 10)
+
     }
     event.stopImmediatePropagation();
   }


### PR DESCRIPTION
Currently, the tree view only updates when switching between already opened tabs. When new files are opened, the user has to click inside the editor for the symbols to appear.
This loads the symbols as soon as the new file is loaded into the editor.